### PR TITLE
restrictions: auto-reconnect the Redis connection for JWT key lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +858,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastwebsockets"
@@ -2226,8 +2241,10 @@ checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itertools 0.13.0",
  "itoa",

--- a/wstunnel/Cargo.toml
+++ b/wstunnel/Cargo.toml
@@ -32,7 +32,7 @@ hyper-util = { version = "0.1.13", features = ["tokio", "server", "server-auto"]
 http-body-util = { version = "0.1.3" }
 jsonwebtoken = "9.3.1"
 log = "0.4.27"
-redis = { version = "0.27", default-features = false, features = ["tokio-comp", "tokio-rustls-comp"] }
+redis = { version = "0.27", default-features = false, features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"] }
 serde_json = "1.0"
 nix = { version = "0.30.1", features = ["socket", "net", "uio"] }
 parking_lot = "0.12.4"

--- a/wstunnel/src/restrictions/jwt.rs
+++ b/wstunnel/src/restrictions/jwt.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 use parking_lot::Mutex;
 use redis::AsyncCommands;
-use redis::aio::MultiplexedConnection;
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -59,7 +59,9 @@ struct CachedKey {
 
 enum KeyFetcher {
     Redis {
-        conn: MultiplexedConnection,
+        // ConnectionManager reconnects in the background (with backoff) when the
+        // underlying connection dies.
+        conn: ConnectionManager,
         keys_hash: String,
     },
     #[cfg(test)]
@@ -106,11 +108,13 @@ impl std::fmt::Debug for JwtVerifier {
 impl JwtVerifier {
     pub async fn from_config(cfg: &JwtRuntimeConfig) -> anyhow::Result<Self> {
         let client = redis::Client::open(cfg.redis_url.as_str()).context("Invalid redis_url")?;
-        let conn_config = redis::AsyncConnectionConfig::new()
+        let conn_config = ConnectionManagerConfig::new()
             .set_connection_timeout(cfg.redis_connect_timeout)
-            .set_response_timeout(cfg.redis_response_timeout);
+            .set_response_timeout(cfg.redis_response_timeout)
+            .set_number_of_retries(2)
+            .set_max_delay(1_000);
         let mut conn = client
-            .get_multiplexed_async_connection_with_config(&conn_config)
+            .get_connection_manager_with_config(conn_config)
             .await
             .context("Failed to open Redis connection")?;
         let _: String = redis::cmd("PING")


### PR DESCRIPTION
MultiplexedConnection has no reconnect logic: once the underlying
socket dies (Redis restart, idle disconnect), every HGET fails with
broken pipe and key lookups stay wedged until the wstunnel-server
process is restarted. The connection only sees traffic on key-cache
misses, so long idle periods make such disconnects likely.

Switch to redis-rs ConnectionManager, which still fails the command
that hit the dead socket (fail-closed) but swaps in a fresh connection
in the background, so subsequent lookups recover without a restart.
A failed HGET is deliberately not retried in place: the client is
assumed to reconnect on its own, so the next HGET is allowed to
recover. The connect/response timeouts from the CLI flags carry over
unchanged.

The reconnect backoff is capped at 2 retries with 1s max delay. The
redis-rs defaults sleep 1s then 60s flat between attempts (its
documented backoff formula is stale; factor=100 reaches backon as a
delay multiplier), i.e. ~5min per burst. Both the initial connect at
startup and any command arriving while a reconnect burst is in flight
wait for the burst to finish, so the cap bounds them to ~2s plus up to
3 connect timeouts instead of minutes. A failed burst is not fatal:
the next HGET simply triggers a new one.